### PR TITLE
env variable to generate trailing slash in location directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ A docker image based on jwilder/nginx-proxy which modifies the template to have 
 
 * NGINX_PROXY_SUBDIRECTORY [REQUIRED]: Specifies the subdirectory to use for this container. If multiple containers have the same subdirectory, nginx will load balance those requests.
 * NGINX_PROXY_SUBDIRECTORY_MAP_TO_ROOT: If 0, maps /$subdir to /$subdir. If 1, maps /$subdir to /. Defaults to 1.
+* NGINX_PROXY_SUBDIRECTORY_TRAILING_SLASH: If 0, location is /$subdir. If 1, location is /$subdir/. Defaults to 1.
 * VIRTUAL_PROTO: Protocol to use for connection to backend container. Defaults to http.

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -28,7 +28,13 @@ upstream {{ $subdir }} {
 
 {{ define "locations" }}
 {{ range $subdir, $containers := groupByMulti $ "Env.NGINX_PROXY_SUBDIRECTORY" "," }}
-	location /{{ $subdir }} {
+        {{ $trailing_slash := or (first (groupByKeys $containers "Env.NGINX_PROXY_SUBDIRECTORY_TRAILING_SLASH")) "1" }}
+        {{ if eq $trailing_slash "1" }}
+        location /{{ $subdir }}/ {
+        {{ else }}
+        location /{{ $subdir }} {
+        {{ end }}
+
 	{{ $proto := or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http" }}
 	{{ $map_to_root := or (first (groupByKeys $containers "Env.NGINX_PROXY_SUBDIRECTORY_MAP_TO_ROOT")) "1" }}
 	{{ if eq $map_to_root "1" }}


### PR DESCRIPTION
trailing slash in container's subdir location seems to be needed for correct url mapping, e.g. in gogs (https://gogs.io/docs/intro/faqs#how-do-i-set-up-a-sub-path-with-nginx%3F)